### PR TITLE
Preserve key object

### DIFF
--- a/lib/json_formatter.ex
+++ b/lib/json_formatter.ex
@@ -7,6 +7,7 @@ defmodule JsonFormatter do
   * Support sigils `:j` and `:J`, shipped with `:jason` version
     `1.3` or newer.
   * Works with `.json` file extension.
+  * Preserves key order.
   """
 
   @behaviour Mix.Tasks.Format
@@ -18,7 +19,8 @@ defmodule JsonFormatter do
 
   @impl true
   def format(contents, _opts) do
-    Jason.decode!(contents)
+    contents
+    |> Jason.decode!(objects: :ordered_objects)
     |> Jason.encode!(pretty: [indent: "  ", line_separator: "\n", after_colon: " "])
   end
 end


### PR DESCRIPTION
Hey!

Thanks for this nifty library!

In its current form, this formatting routine has undetermined key order (depending on Erlangs mood, it may totally change when you have larger maps). Also it generates huge diffs on hand written JSONs because usually humans tend to sort the keys to taste.

This PR makes the formatter use Jason's new OrderedObjects feature to presere key order and thus make the output a bit nicer.